### PR TITLE
Fix up sphinx generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,5 +11,5 @@ python runscript.py
 ## Documentation
 First auto-generate the *.rst files
 ```
-sphinx-apidoc --force -o docs/_modules . Data
+env SPHINX_APIDOC_OPTIONS=members sphinx-apidoc --force -o docs/_modules . runscript.py Data
 ```

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -35,8 +35,7 @@ extensions = [
     'sphinx.ext.doctest',
     'sphinx.ext.intersphinx',
     'sphinx.ext.todo',
-    'sphinx.ext.coverage',
-    'sphinx.ext.viewcode'
+    'sphinx.ext.coverage'
 ]
 
 # Add any paths that contain templates here, relative to this directory.


### PR DESCRIPTION
There was a problem where all source code were embedded in
the HTML and none of the docstring was used. Removed viewcode
extensions to fix the problem